### PR TITLE
Fix studio show page

### DIFF
--- a/app/views/studios/show.html.erb
+++ b/app/views/studios/show.html.erb
@@ -1,9 +1,16 @@
 <div class="container text-center">
   <h1>Photos by <%= @studio.name %></h1>
   <p>
-    <%= @studio %>
+    <%= @studio.description %>
   </p>
+  <p>
   <% @studio.photos.each do |photo| %>
-  <%= render partial: 'partials/photo_column', locals: { photo: photo } %>
+    <%= render partial: 'partials/photo_column', locals: { photo: photo } %>
+    <% if photo.active %>
+      <%= link_to "Add to Cart", cart_photos_path(photo_id: photo.id), method: :post, class: "btn btn-default" %>
+    <% else %>
+      <h3><%= "Sorry, this photo is no longer available" %></h3>
+    <% end %>
   <% end %>
+  </p>
 </div>

--- a/test/integration/user_view_studio_test.rb
+++ b/test/integration/user_view_studio_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class UserViewStudioTest < ActionDispatch::IntegrationTest
+  test "they see the studio information" do
+    category = Category.create(name: "Example Category")
+
+    studio = Studio.create(name:        "Studio",
+                            description: "Example description.",
+                            status:      0
+    )
+
+    photo1 = studio.photos.create(name:        "Example Name1",
+                                   description: "Example Description1",
+                                   image:       "https://placeholdit.imgix.net/~text?txtsize=60&bg=000000&txt=640%C3%97480&w=640&h=480&fm=png",
+                                   price:       999,
+                                   category_id: category.id
+    )
+    photo2 = studio.photos.create(name:        "Example Name2",
+                                   description: "Example Description2",
+                                   image:       "https://placeholdit.imgix.net/~text?txtsize=60&bg=000000&txt=640%C3%97480&w=640&h=480&fm=png",
+                                   price:       999,
+                                   category_id: category.id
+    )
+
+    visit studio_path(studio)
+
+    assert page.has_content? studio.name
+    assert page.has_content? studio.description
+    assert page.has_content? photo1.name
+    assert page.has_content? photo2.name
+  end
+end


### PR DESCRIPTION
User can view a studio show page.
Studio show page shows relevant info like studio name and description.
Photos on studio show page can be added to cart if available

Definitely opportunity for refactoring with duplication of the add to cart for photos.

closes #38
