### PR TITLE
Scope studio admin orders index

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,8 +1,9 @@
 class Admin::OrdersController < Admin::BaseController
   def index
-    @orders = Order.all
-    @grid = OrdersGrid.new(params[:orders_grid]) do |scope|
-      scope.page(params[:page])
+    @orders = Order.all.select do |order|
+      order.order_photos.any? do |order_photo|
+        order_photo.photo.studio == current_user.studio
+      end
     end
   end
 

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,21 +1,19 @@
 <div class="container">
   <h1 class="text-center">.all_orders for gifs_for_good</h1>
-  <span class="status_breakdown">
-    <table class="table table-striped span:inline">
-      <tr><th>Order Statuses</th></tr>
-      <% if @orders %>
-        <% @orders.status_breakdown.each do |status, amount| %>
-          <tr>
-            <td><%= "#{status.capitalize}: #{amount}" %></td>
-          </tr>
-        <% end %>
-      <% end %>
-    </table>
-  </span>
   <div class="all_orders col-md-offset-1">
-    <%= datagrid_form_for @grid, :method => :get, :url => admin_orders_path %>
-    <%= paginate(@grid.assets) %>
-    <%= datagrid_table @grid %>
-    <%= paginate(@grid.assets) %>
+    <table>
+      <th>
+        <td>Order</td>
+        <td>Placed At</td>
+        <td>Price</td>
+      </th>
+      <tr>
+        <% @orders.each do |order| %>
+          <td> <%= link_to order.id, admin_order_path(order) %></td>
+          <td> <%= order.created_at %></td>
+          <td> <%= order.total_price %></td>
+        <% end %>
+      </tr>
+    </table>
   </div>
 </div>

--- a/test/integration/studio_admin_cannot_view_orders_for_another_studio_test.rb
+++ b/test/integration/studio_admin_cannot_view_orders_for_another_studio_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class StudioAdminCanOnlyViewTheirOrdersTest < ActionDispatch::IntegrationTest
+  test "studio admin tries to view an order that is not theirs and can't" do
+    category = Category.create(name: "Example Category")
+
+    studio = Studio.create(name:        "Studio",
+                           description: "Example description.",
+                           status:      0
+    )
+    other_studio = Studio.create(name:        "Other Studio",
+                                description:  "Example description2.",
+                                status:      0
+    )
+
+    admin = studio.users.create(email:  "admin@eample.com",
+                                password: "password",
+                                role:     1
+    )
+
+    user = User.create(email:  "example@eample.com",
+                        password: "password",
+                        role:     0
+    )
+
+    photo = studio.photos.create(name:        "Example Name",
+                                 description: "Example Description",
+                                 image:       "https://placeholdit.imgix.net/~text?txtsize=60&bg=000000&txt=640%C3%97480&w=640&h=480&fm=png",
+                                 price:       999,
+                                 category_id: category.id
+    )
+
+    other_photo = other_studio.photos.create(name:        "Example Name 2",
+                                             description: "Example Description2",
+                                             image:       "https://placeholdit.imgix.net/~text?txtsize=60&bg=000000&txt=640%C3%97480&w=640&h=480&fm=png",
+                                             price:       999,
+                                             category_id: category.id
+    )
+
+    op = OrderPhoto.create(photo_id: photo.id)
+    order = user.orders.create(total_price: 200)
+    order.order_photos << op
+
+    op2 = OrderPhoto.create(photo_id: other_photo.id)
+    order2 = user.orders.create(total_price: 200)
+    order2.order_photos << op2
+
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit admin_orders_path
+    assert page.has_content?(order.id)
+    refute page.has_content?(order2.id)
+  end
+end


### PR DESCRIPTION
Orders on studio admin's index only shows orders that includes photos from that studio
Grid is gone - we might pull this back in for platform admin

closes #54 closes #78 closes #77
