### PR TITLE
New photo form price takes dollars #89

### DIFF
--- a/app/controllers/admin/photos_controller.rb
+++ b/app/controllers/admin/photos_controller.rb
@@ -7,6 +7,7 @@ class Admin::PhotosController < Admin::BaseController
   def create
     @photo = Photo.new(photo_params)
     @photo.update_attributes(studio_id: current_user.studio.id)
+    @photo.set_price
     if @photo.save
       flash[:success] = "Your Photo Has Been Created"
       redirect_to photo_path(@photo)

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -7,30 +7,4 @@ class PhotosController < ApplicationController
     @photo = Photo.find(params[:id])
     @studio = @photo.studio
   end
-
-  # def create
-  #   @gif = Gif.new(gif_params)
-  #   if @gif.save
-  #     tags = params[:tags].split(",")
-  #     @gif.create_tags(tags)
-  #     Charity.find_by(name: params[:charity]).gifs << @gif
-  #     flash[:success] = "Your photo has been created"
-  #     redirect_to gif_path(@gif)
-  #   else
-  #     flash.now[:error] = "Invalid Entry, Try again."
-  #     render new_admin_gif_path
-  #   end
-  # end
-
-  def update
-    @gif = find_gif
-    @gif.update_attributes(retired: true)
-    redirect_to gif_path(@gif.id)
-  end
-
-private
-
-  def gif_params
-    params.require(:gif).permit(:title, :description, :price, :tag, :image)
-  end
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -33,4 +33,8 @@ class Photo < ActiveRecord::Base
   def self.all_active
     Gif.all.each { |gif| gif.active }
   end
+
+  def set_price
+    self.price = price * 100
+  end
 end

--- a/app/views/admin/photos/new.html.erb
+++ b/app/views/admin/photos/new.html.erb
@@ -6,8 +6,9 @@
   <%= f.text_field :name %>
     <h4><%= f.label :description %></h4>
   <%= f.text_field :description %>
-    <h4><%= f.label :price_in_dollars %></h4>
+    <h4><%= f.label :price %></h4>
   <%= f.text_field :price %>
+  <small>Input price in dollars</small>
     <h4><%= f.label :image %></h4>
   <%= f.file_field :image %>
   <%= f.label :category %>

--- a/app/views/admin/photos/new.html.erb
+++ b/app/views/admin/photos/new.html.erb
@@ -6,7 +6,7 @@
   <%= f.text_field :name %>
     <h4><%= f.label :description %></h4>
   <%= f.text_field :description %>
-    <h4><%= f.label :price %></h4>
+    <h4><%= f.label :price_in_dollars %></h4>
   <%= f.text_field :price %>
     <h4><%= f.label :image %></h4>
   <%= f.file_field :image %>

--- a/test/integration/studio_admin_can_create_photo_test.rb
+++ b/test/integration/studio_admin_can_create_photo_test.rb
@@ -23,7 +23,7 @@ class StudioAdminCanCreatePhotoTest < ActionDispatch::IntegrationTest
 
     fill_in "Name",        with: "Example Name"
     fill_in "Description", with: "Example Description"
-    fill_in "Price",       with: "999"
+    fill_in "Price",       with: "9.99"
     select "A Category", from: "photo[category_id]"
     attach_file "Image", "test/asset_tests/photos/sample_photo.jpg"
     click_on "Create Photo"
@@ -39,5 +39,20 @@ class StudioAdminCanCreatePhotoTest < ActionDispatch::IntegrationTest
     end
 
     assert page.has_content?("Your Photo Has Been Created")
+
+    visit new_admin_photo_path
+
+    fill_in "Name",        with: "Example Name"
+    fill_in "Description", with: "Example Description"
+    fill_in "Price",       with: "10"
+    select "A Category", from: "photo[category_id]"
+    attach_file "Image", "test/asset_tests/photos/sample_photo.jpg"
+    click_on "Create Photo"
+
+    assert page.has_content?("Your Photo Has Been Created")
+
+    visit photo_path(Photo.last)
+
+    assert page.has_content?("$10.00")
   end
 end

--- a/test/integration/visitor_views_two_photos_in_cart_test.rb
+++ b/test/integration/visitor_views_two_photos_in_cart_test.rb
@@ -41,7 +41,7 @@ class VisitorViewsTwoPhotosInCartTest < ActionDispatch::IntegrationTest
     assert page.has_link? photo2.name
     assert page.has_link? category.name
     assert page.has_content? "$9.99"
-    assert page.has_content? ("19.98")
+    assert page.has_content? "19.98"
 
     assert page.has_link? "Continue Shopping"
     assert page.has_content? "Checkout"


### PR DESCRIPTION
closes #89 

I created a method so that when a photo is created through the studio admin form, it expects dollars and will save the attribute in the DB as cents. Some other miscellaneous changes too; see commit log.
