### PR TITLE
Studio admin cannot view platform admin dashboard

### DIFF
--- a/test/integration/studio_admin_cannot_view_platform_admin_dashboard_test.rb
+++ b/test/integration/studio_admin_cannot_view_platform_admin_dashboard_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class StudioAdminCannotViewPlatformAdminDashboardTest < ActionDispatch::IntegrationTest
+  test "studio admin sees a 404 page when attempting to visit platform admin dashboard" do
+    studio = create_studio
+    create_and_login_studio_admin(studio)
+
+    visit platform_admin_dashboard_path
+
+    assert page.has_content? "The page you were looking for doesn't exist"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -102,12 +102,21 @@ class ActionDispatch::IntegrationTest
     ApplicationController.any_instance.stubs(:current_user).returns(admin)
   end
 
-  def create_and_login_platform_admin(studio)
+  def create_and_login_studio_platform_admin(studio)
     admin = studio.users.create(email:  "admin@eample.com",
                                 password: "password",
                                 )
     admin.roles << customer_role
     admin.roles << studio_admin_role
+    admin.roles << platform_admin_role
+    admin
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+  end
+
+  def create_and_login_platform_admin(studio)
+    admin = studio.users.create(email:  "admin@eample.com",
+                                password: "password",
+                                )
     admin.roles << platform_admin_role
     admin
     ApplicationController.any_instance.stubs(:current_user).returns(admin)


### PR DESCRIPTION
Add test helper method for non studio platform admin
