### PR TITLE
Guest cannot view platform admin dashboard

### DIFF
--- a/test/integration/guest_cannot_view_platform_admin_dashboard_test.rb
+++ b/test/integration/guest_cannot_view_platform_admin_dashboard_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class GuestCannotViewPlatformAdminDashboardTest < ActionDispatch::IntegrationTest
+  test "guest sees a 404 page when attempting to visit platform admin dashboard" do
+    visit platform_admin_dashboard_path
+
+    assert page.has_content? "The page you were looking for doesn't exist"
+  end
+end


### PR DESCRIPTION
Code was already implemented, now it's tested.

Closes #139
