### PR TITLE
Add permission for platform admin to edit studio info

### DIFF
--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -27,7 +27,7 @@ class StudiosController < ApplicationController
 
   def edit
     studio = Studio.find(params[:id])
-    if current_user.studio != studio
+    if (!current_platform_admin?) && (current_user.studio != studio)
       flash[:alert] = "You can only edit a studio that belongs to you"
       render file: "/public/404"
     else

--- a/test/integration/platform_admin_edits_studio_info_test.rb
+++ b/test/integration/platform_admin_edits_studio_info_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class PlatformAdminEditsStudioInfoTest < ActionDispatch::IntegrationTest
+  test "platform admin can edit their studio info" do
+    studio = create_studio
+    admin  = create_and_login_studio_platform_admin(studio)
+
+    visit admin_path(studio)
+
+    click_on "Edit Studio"
+    fill_in "Name", with: "Updated Name"
+
+    click_on "Update Studio"
+
+    assert page.has_content?("Your studio has been updated!")
+    assert page.has_content?("Updated Name")
+  end
+
+  test "platform admin can edit another studios info" do
+    studio = create_studio
+    admin  = create_and_login_platform_admin
+
+    visit admin_path(studio)
+    click_on "Edit Studio"
+
+    fill_in "Name", with: "Different Updated Name"
+
+    click_on "Update Studio"
+
+    assert page.has_content?("Your studio has been updated!")
+    assert page.has_content?("Different Updated Name")
+  end
+end


### PR DESCRIPTION
Add permission in branch for platform admin to edit studio
Add test for PA edit studio info; tests both a PA's associated studio and a non-associated studio.

closes #145
