### PR TITLE
Overwrite to param and find methods for category

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,6 +1,6 @@
 class CategoriesController < ApplicationController
   def show
-    @category = Category.find_by(slug: params[:slug])
+    @category = Category.find(params[:id])
   end
 
   def index

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -9,4 +9,12 @@ class Category < ActiveRecord::Base
   def set_slug
     self.slug = name.parameterize
   end
+
+  def to_param
+    slug
+  end
+
+  def self.find(input)
+    find_by_slug(input)
+  end
 end

--- a/app/views/cart_photos/show.html.erb
+++ b/app/views/cart_photos/show.html.erb
@@ -22,7 +22,7 @@
             <td><%= image_tag photo.image, width: 80 %></td>
             <td><%= link_to photo.name, photo_path(photo) %>
             <p><%= photo.description %></p></td>
-            <td><%= link_to Category.find(photo.category_id).name, category_path(Category.find(photo.category_id).slug) %></td>
+            <td><%= link_to Category.find_by(id: photo.category_id).name, category_path(Category.find_by(id: photo.category_id)) %></td>
             <td><%= format_price(photo.price) %></td>
             <td>
               <p><%= link_to "Remove from Cart", cart_path(id: photo.id), method: :delete %></p>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -3,7 +3,7 @@
     <h1>All Categories</h1>
     <% @categories.each do |category| %>
       <div class="col-md-4">
-        <h4> <%= link_to "#{category.name}", category_path(category.slug) %></h2>
+        <h4> <%= link_to "#{category.name}", category_path(category) %></h2>
       </div>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,5 @@ Rails.application.routes.draw do
 
   resources :studios
 
-  resources :categories, only: [:index]
-  get "/categories/:slug", :to => "categories#show", as: :category
+  resources :categories, only: [:index, :show]
 end

--- a/test/integration/customer_can_only_have_one_of_each_photo_in_cart_test.rb
+++ b/test/integration/customer_can_only_have_one_of_each_photo_in_cart_test.rb
@@ -21,7 +21,7 @@ class CustomerCanOnlyHaveOneOfEachPhotoInCartTest < ActionDispatch::IntegrationT
 
     assert page.has_content? "Cart(1)"
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     click_on photo2.name
     click_on "Add to Cart"
@@ -29,7 +29,7 @@ class CustomerCanOnlyHaveOneOfEachPhotoInCartTest < ActionDispatch::IntegrationT
     assert page.has_content? "Photo has been added to cart"
     assert page.has_content? "Cart(2)"
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     click_on photo2.name
     click_on "Add to Cart"

--- a/test/integration/registered_user_cannot_see_inactive_photos_test.rb
+++ b/test/integration/registered_user_cannot_see_inactive_photos_test.rb
@@ -10,14 +10,14 @@ class RegisteredUserCannotSeeInactivePhotosTest < ActionDispatch::IntegrationTes
 
     ApplicationController.any_instance.stubs(:current_user).returns(user)
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     assert page.has_content?("Photo 1")
     assert page.has_content?("Photo 2")
 
     photo_2 = Photo.last.update(active: false)
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     assert page.has_content?("Photo 1")
     refute page.has_content?("Photo 2")

--- a/test/integration/studio_admin_activates_inactive_photo_test.rb
+++ b/test/integration/studio_admin_activates_inactive_photo_test.rb
@@ -27,7 +27,7 @@ class StudioAdminActivatesPhotoTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Deactivate")
     end
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     assert page.has_content?(photo.name)
   end

--- a/test/integration/studio_admin_deactivates_photo_test.rb
+++ b/test/integration/studio_admin_deactivates_photo_test.rb
@@ -20,7 +20,7 @@ class StudioAdminDeactivatesPhotoTest < ActionDispatch::IntegrationTest
       refute page.has_content?("Deactivate")
     end
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     refute page.has_content?(photo.name)
   end

--- a/test/integration/visitor_can_add_photos_to_cart_test.rb
+++ b/test/integration/visitor_can_add_photos_to_cart_test.rb
@@ -22,7 +22,7 @@ class VisitorCanAddPhotosToCartTest < ActionDispatch::IntegrationTest
 
     assert page.has_content? "Cart(1)"
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     click_on photo2.name
     click_on "Add to Cart"

--- a/test/integration/visitor_views_two_photos_in_cart_test.rb
+++ b/test/integration/visitor_views_two_photos_in_cart_test.rb
@@ -12,12 +12,12 @@ class VisitorViewsTwoPhotosInCartTest < ActionDispatch::IntegrationTest
                                  price:       999,
                                  category_id: category.id
     )
-    visit category_path(category.slug)
+    visit category_path(category)
 
     click_on photo1.name
     click_on "Add to Cart"
 
-    visit category_path(category.slug)
+    visit category_path(category)
 
     click_on photo2.name
     click_on "Add to Cart"


### PR DESCRIPTION
Slug is now used for param and find methods in category.
Remove reference to slug in route as to param handles this.
Fix category path helper in tests to not call slug
Fix cart photo show to use new param and find methods.

closes #156
