### PR TITLE
update controller to handle non-logged-in user

### DIFF
--- a/app/controllers/studios_controller.rb
+++ b/app/controllers/studios_controller.rb
@@ -5,6 +5,7 @@ class StudiosController < ApplicationController
 
   def show
     @studio = Studio.find(params[:id])
+    render file: "/public/404" unless @studio.active? || current_platform_admin? || current_user && current_user.studio == @studio
   end
 
   def new

--- a/app/views/platform_admin/studios/index.html.erb
+++ b/app/views/platform_admin/studios/index.html.erb
@@ -16,7 +16,7 @@
     <tr>
       <td><%= link_to studio.id, admin_path(studio) %></td>
       <td><%= link_to studio.name, admin_path(studio) %></td>
-      <td><%= button_to "View/Edit", admin_path(studio) %></td>
+      <td><%= link_to "View/Edit", admin_path(studio), class: "btn btn-primary btn-large" %></td>
       <td><%= studio.studio_created_on %></td>
       <td><%= studio.status %></td>
       <% if studio.active? %>

--- a/test/integration/registered_user_cannot_access_inactive_studio_test.rb
+++ b/test/integration/registered_user_cannot_access_inactive_studio_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class RegisteredUserCannotAccessInactiveStudioTest < ActionDispatch::IntegrationTest
+  test "registered user tries to access inactive studio" do
+    user = create_user
+    active = create_studio
+    inactive_studio = Studio.create(name:        "inactive",
+                                    description: "Example description.",
+                                    status:      1,
+                                    promo_image: "https://placeholdit.imgix.net/~text?txtsize=60&bg=000000&txt=640%C3%97480&w=640&h=480&fm=png"
+                                    )
+    pending_studio = Studio.create(name:        "pending",
+                                    description: "Example description.",
+                                    status:      2,
+                                    promo_image: "https://placeholdit.imgix.net/~text?txtsize=60&bg=000000&txt=640%C3%97480&w=640&h=480&fm=png"
+                                    )
+    denied_studio = Studio.create(name:        "denied",
+                                    description: "Example description.",
+                                    status:      3,
+                                    promo_image: "https://placeholdit.imgix.net/~text?txtsize=60&bg=000000&txt=640%C3%97480&w=640&h=480&fm=png"
+                                    )
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+
+    visit studios_path
+    assert page.has_content?(active.name)
+    refute page.has_content?(inactive_studio.name)
+    refute page.has_content?(pending_studio.name)
+    refute page.has_content?(denied_studio.name)
+    visit studio_path(inactive_studio)
+    assert page.has_content?("The page you were looking for doesn't exist")
+    visit studio_path(pending_studio)
+    assert page.has_content?("The page you were looking for doesn't exist")
+    visit studio_path(denied_studio)
+    assert page.has_content?("The page you were looking for doesn't exist")
+  end
+end


### PR DESCRIPTION
Write test
Change permissions so that when accessing studio show page via url, only that studio's admins and platform admins can access it. 

closes #141
