### PR TITLE
Prevent inactive studio admin from activating photos

### DIFF
--- a/app/controllers/admin/photos_controller.rb
+++ b/app/controllers/admin/photos_controller.rb
@@ -36,6 +36,12 @@ class Admin::PhotosController < Admin::BaseController
   end
 
   def change_status
+    studio = Studio.find_by(id: params[:studio])
+    unless studio.status == "active"
+      flash[:error] = "That action is prohibited."
+      redirect_to :back and return
+    end
+
     @photo = Photo.find(params[:id])
     if @photo.active
       @photo.update_attributes(active: false)

--- a/test/integration/admin_for_inactive_studio_cannot_activate_photos_test.rb
+++ b/test/integration/admin_for_inactive_studio_cannot_activate_photos_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class AdminForInactiveStudioCannotActivatePhotoTest < ActionDispatch::IntegrationTest
+  test "attemps to activate a photo and gets a 404" do
+    category = create_category
+    studio   = create_studio
+    photo    = create_studio_photo(studio, category)
+    admin    = create_and_login_studio_admin(studio)
+
+    studio.update_attributes(status: 1)
+    photo.update_attributes(active: false)
+
+    visit photo_path(photo)
+
+    click_on "Activate"
+
+    assert_equal photo_path(photo), current_path
+    assert page.has_content?("That action is prohibited.")
+  end
+end


### PR DESCRIPTION
Added logic in controller change status method to prevent
studio other than active from activating photos

closes #160
