### PR TITLE
Hide studio status from unauthorized users

### DIFF
--- a/app/models/studio.rb
+++ b/app/models/studio.rb
@@ -16,7 +16,7 @@ class Studio < ActiveRecord::Base
     }
 
   validates_attachment_content_type :promo_image, :content_type => /\Aimage\/.*\Z/
-  before_create :set_slug
+  before_save :set_slug
 
   enum status: %w(active inactive pending denied)
 

--- a/app/views/studios/show.html.erb
+++ b/app/views/studios/show.html.erb
@@ -1,11 +1,13 @@
-<div class="container">  
+<div class="container">
   <div class="row product photo-show-photo">
     <div class="col-md-offset-1 col-md-5">
       <%= image_tag @studio.promo_image, width: 400 %>
     </div>
     <div class="container col-md-offset-1 col-xs-12 col-md-4 photo-show">
       <h1>Photos by <%= @studio.name %></h1>
-      <h4>Status: <%= @studio.status %></h4>
+      <% if current_user && (current_user.platform_admin? || current_user.relevent_studio_admin(@studio)) %>
+        <h4>Status: <%= @studio.status %></h4>
+      <% end %>
       <p><%= @studio.description %></p>
     </div>
     <div class="gifs">

--- a/test/integration/studio_status_hidden_for_non_admins_test.rb
+++ b/test/integration/studio_status_hidden_for_non_admins_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class StudioStatusHiddenForNonAdminsTest < ActionDispatch::IntegrationTest
+  test "guest cannot see studio status" do
+    category = create_category
+    studio   = create_studio
+
+    visit studio_path(studio)
+
+    refute page.has_content?("Status")
+
+    studio.update_attribute(:status, "pending")
+
+    visit studio_path(studio)
+
+    refute page.has_content?("Status")
+  end
+
+  test "registered user cannot see studio status" do
+    category = create_category
+    studio   = create_studio
+    user     = create_and_login_user
+
+    visit studio_path(studio)
+
+    refute page.has_content?("Status")
+  end
+
+  test "non-affiliated admin cannot see studio status" do
+    category = create_category
+
+    studio_1 = create_studio
+    studio_1.update_attribute(:name, "Studio 1")
+
+    studio_2 = create_studio
+    studio_2.update_attribute(:name, "Studio 2")
+
+    user     = create_and_login_studio_admin(studio_1)
+
+    visit studio_path(studio_2)
+
+    refute page.has_content?("Status")
+
+    visit studio_path(studio_1)
+
+    assert page.has_content?("Status")
+  end
+end


### PR DESCRIPTION
Studio status only appears for platform admin and that studio's admin
Changed set slug method to run after save rather than create, will now
reset after updates and creates.

note: branch was misnamed :tired_face: 

closes #186
